### PR TITLE
Enable  key_vault_secrets_provider story changes

### DIFF
--- a/examples/scca_private_cluster_commercial/main.tf
+++ b/examples/scca_private_cluster_commercial/main.tf
@@ -33,9 +33,11 @@ module "aks_cluster" {
   workload_name                = var.workload_name
   environment                  = var.environment
   #custom_cluster_name         = "testaks"
-  dns_prefix = "testaksdns"
+  dns_prefix = "aksdns"
 
-  azure_policy_enabled = false
+  azure_policy_enabled       = false
   log_analytics_workspace_id = azurerm_log_analytics_workspace.aks.id
 
+  enable_key_vault_secrets_provider = false
+ 
 }

--- a/examples/scca_private_cluster_gov/main.tf
+++ b/examples/scca_private_cluster_gov/main.tf
@@ -32,10 +32,12 @@ module "aks_cluster" {
   deploy_environment           = var.deploy_environment
   workload_name                = var.workload_name
   environment                  = var.environment
-  dns_prefix                   = "testaksdns"
+  dns_prefix                   = "aksdns"
 
   azure_policy_enabled       = true
   log_analytics_workspace_id = azurerm_log_analytics_workspace.aks.id
 
+  enable_key_vault_secrets_provider = true
+ 
 }
 

--- a/resources.kubernetes.tf
+++ b/resources.kubernetes.tf
@@ -20,11 +20,14 @@ resource "azurerm_kubernetes_cluster" "aks_cluster" {
 
   node_resource_group = local.node_resource_group
 
-
-
+  key_vault_secrets_provider {
+    secret_rotation_enabled = var.enable_key_vault_secrets_provider
+  }
+  
   private_cluster_enabled       = true  // private cluster is always enabled based on the current implementation (SCCA)
+
   public_network_access_enabled = false // public network access is always disabled based on the current implementation (SCCA)
-  sku_tier                      = var.sku_tier
+   sku_tier                      = var.sku_tier
 
   private_dns_zone_id = local.private_dns_zone_id
   #  dns_prefix_private_cluster = local.dns_prefix

--- a/variables.resources.kubernetes.tf
+++ b/variables.resources.kubernetes.tf
@@ -546,6 +546,13 @@ variable "enable_azure_policy" {
   default     = false
 }
 
+
+variable "enable_key_vault_secrets_provider" {
+  description = "Addon profile to integrate Azure KeyVault with AKS"
+  type        = bool
+  default     = false
+}
+
 variable "api_server_authorized_ip_ranges" {
   description = "authorized IP ranges to communicate with K8s API"
   type        = map(string)


### PR DESCRIPTION
## Describe your changes

Only added changes to enable the add on azureKeyvaultSecretsProvider which also install the CSI drivers required to connect to KeyVault from AKS.  To have Keyvault integrate to AKS other changes also required, going to create a separate story. 

Files modified:

1. Variables.resources.kubernetes.tf 
2. Resources.kubernetes.tf
3. Main.tf - gov
4. Main.tf - Commercial 

## Issue number # 24 AKS-KeyVault to manage keys  


#24 

## Checklist before requesting a review
- [ ] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [ ] I have executed pre-commit on my machine
- [ ] I have passed pr-check on my machine

Thanks for your cooperation!

