### PR TITLE
31 integrate aks with azure keyvault

### DIFF
--- a/examples/scca_private_cluster_commercial/main.tf
+++ b/examples/scca_private_cluster_commercial/main.tf
@@ -38,6 +38,6 @@ module "aks_cluster" {
   azure_policy_enabled       = false
   log_analytics_workspace_id = azurerm_log_analytics_workspace.aks.id
 
-  enable_key_vault_secrets_provider = false
+  create_aks_keyvault = true
  
 }

--- a/examples/scca_private_cluster_gov/main.tf
+++ b/examples/scca_private_cluster_gov/main.tf
@@ -36,8 +36,8 @@ module "aks_cluster" {
 
   azure_policy_enabled       = true
   log_analytics_workspace_id = azurerm_log_analytics_workspace.aks.id
-
-  enable_key_vault_secrets_provider = true
+  
+  create_aks_keyvault = true
  
 }
 

--- a/modules.kubernetes.keyvault.tf
+++ b/modules.kubernetes.keyvault.tf
@@ -24,10 +24,13 @@ module "mod_key_vault" {
   # By default this will create a `privatelink.vaultcore.azure.net` DNS zone. if created in commercial cloud
   # To use existing subnet, specify `existing_private_subnet_name` with valid subnet name. 
   # To use existing private DNS zone specify `existing_private_dns_zone` with valid zone name.
-  enable_private_endpoint      = var.create_aks_keyvault
-  virtual_network_name         = var.keyvault_virtual_network_name != null ? var.keyvault_virtual_network_name : null
-  existing_private_dns_zone    = var.existing_keyvault_private_dns_zone != null ? var.existing_keyvault_private_dns_zone : null
-  existing_private_subnet_name = var.existing_keyvault_private_subnet_name
+   
+  #enable_private_endpoint      = var.create_apim_keyvault
+  #virtual_network_name         = var.virtual_network_name != null ? var.virtual_network_name : null
+  #existing_private_dns_zone    = var.existing_keyvault_private_dns_zone != null ? var.existing_keyvault_private_dns_zone : null
+  #existing_private_subnet_name = var.existing_private_subnet_name != null ? data.azurerm_subnet.snet.0.name : null
+
+
 
   # Current user should be here to be able to create keys and secrets
   #admin_objects_ids = [
@@ -50,10 +53,17 @@ resource "azurerm_key_vault_access_policy" "aks_access_policy" {
   count = var.create_aks_keyvault && var.identity_type == "UserAssigned" ? 1 : 0
   key_vault_id = module.mod_key_vault.0.key_vault_id
   tenant_id    = data.azurerm_subscription.current.tenant_id
-  object_id    = azurerm_user_assigned_identity.aks[0].principal_id
+  object_id  = azurerm_kubernetes_cluster.aks_cluster.kubelet_identity.0.object_id
+
+  
+  key_permissions = [
+    "Get",
+  ]
 
   secret_permissions = [
     "Get",
     "List",
+    "Set", 
+    "Delete"
   ]
 }

--- a/modules.kubernetes.keyvault.tf
+++ b/modules.kubernetes.keyvault.tf
@@ -1,0 +1,59 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+module "mod_key_vault" {
+  depends_on = [
+    azurerm_user_assigned_identity.aks
+  ]
+  source                       = "azurenoops/overlays-key-vault/azurerm"
+  version                      = "~> 2.0"
+  count                        = var.create_aks_keyvault ? 1 : 0
+  existing_resource_group_name = local.resource_group_name
+  location                     = local.location
+  environment                  = var.environment
+  deploy_environment           = var.deploy_environment
+  org_name                     = var.org_name
+  workload_name                = var.workload_name
+
+  # Key Vault Configuration
+  sku_name = var.key_vault_sku_name
+  enable_purge_protection = var.purge_protection_enabled
+  enabled_for_deployment = var.enabled_for_template_deployment
+
+  # Creating Private Endpoint requires, VNet name to create a Private Endpoint
+  # By default this will create a `privatelink.vaultcore.azure.net` DNS zone. if created in commercial cloud
+  # To use existing subnet, specify `existing_private_subnet_name` with valid subnet name. 
+  # To use existing private DNS zone specify `existing_private_dns_zone` with valid zone name.
+  enable_private_endpoint      = var.create_aks_keyvault
+  virtual_network_name         = var.keyvault_virtual_network_name != null ? var.keyvault_virtual_network_name : null
+  existing_private_dns_zone    = var.existing_keyvault_private_dns_zone != null ? var.existing_keyvault_private_dns_zone : null
+  existing_private_subnet_name = var.existing_keyvault_private_subnet_name
+
+  # Current user should be here to be able to create keys and secrets
+  #admin_objects_ids = [
+  #  data.azuread_group.admin_group.id
+  #]
+
+  # This is to enable resource locks for the key vault. 
+  enable_resource_locks = var.enable_resource_locks
+
+  # Tags for Azure Resources
+  add_tags = merge(var.add_tags, local.default_tags)
+}
+
+# Create Access Policy for API Service Identity. This is a workaround for the bug in the azurenoops/overlays-key-vault/azurerm module
+resource "azurerm_key_vault_access_policy" "aks_access_policy" {
+  depends_on = [
+    module.mod_key_vault,
+    azurerm_user_assigned_identity.aks
+  ]
+  count = var.create_aks_keyvault && var.identity_type == "UserAssigned" ? 1 : 0
+  key_vault_id = module.mod_key_vault.0.key_vault_id
+  tenant_id    = data.azurerm_subscription.current.tenant_id
+  object_id    = azurerm_user_assigned_identity.aks[0].principal_id
+
+  secret_permissions = [
+    "Get",
+    "List",
+  ]
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -88,3 +88,11 @@ output "kubelet_identity" {
   description = "kubelet identity information"
   value       = azurerm_kubernetes_cluster.aks_cluster.kubelet_identity.0
 }
+
+  
+
+
+
+
+
+

--- a/resources.kubernetes.tf
+++ b/resources.kubernetes.tf
@@ -21,13 +21,15 @@ resource "azurerm_kubernetes_cluster" "aks_cluster" {
   node_resource_group = local.node_resource_group
 
   key_vault_secrets_provider {
-    secret_rotation_enabled = var.enable_key_vault_secrets_provider
+    secret_rotation_enabled = true
   }
-  
+ 
   private_cluster_enabled       = true  // private cluster is always enabled based on the current implementation (SCCA)
 
-  public_network_access_enabled = false // public network access is always disabled based on the current implementation (SCCA)
-   sku_tier                      = var.sku_tier
+   public_network_access_enabled = false // public network access is always disabled based on the current implementation (SCCA)
+  # `public_network_access_enabled` is currently not functional and is not be passed to the API
+
+  sku_tier                      = var.sku_tier
 
   private_dns_zone_id = local.private_dns_zone_id
   #  dns_prefix_private_cluster = local.dns_prefix
@@ -70,12 +72,15 @@ resource "azurerm_kubernetes_cluster" "aks_cluster" {
 
   identity {
     type = var.identity_type
-    identity_ids = (var.identity_type == "SystemAssigned" ? null :
+    
+     identity_ids = (var.identity_type == "SystemAssigned" ? null :
       (var.user_assigned_identity != null ?
         [var.user_assigned_identity.id] :
-    [azurerm_user_assigned_identity.aks.0.id]))
+    [azurerm_user_assigned_identity.aks.0.id]))  
   }
 
+ 
+  
   api_server_authorized_ip_ranges = local.api_server_authorized_ip_ranges
 
   oms_agent {

--- a/variables.keyvault.tf
+++ b/variables.keyvault.tf
@@ -31,7 +31,7 @@ variable "key_vault_sku_name" {
   default     = "standard"
 }
 
-variable "keyvault_virtual_network_name" {
+variable "virtual_network_name" {
   description = "The name of the virtual network to create the Key Vault private endpoint in."
   type        = string
   default     = null

--- a/variables.keyvault.tf
+++ b/variables.keyvault.tf
@@ -1,0 +1,50 @@
+##########################
+# KeyVault Configuration #
+##########################
+variable "create_aks_keyvault" {
+  description = "Controls if the keyvault should be created. If set to false, the keyvault name must be provided. Default is false."
+  type        = bool
+  default     = false
+}
+
+variable "key_vault_custom_name" {
+  description = "Custom name for the keyvault. If not set, the name will be generated using the `org_name`, `workload_name`, `deploy_environment` and `environment` variables."
+  type        = string
+  default     = null
+}
+
+variable "purge_protection_enabled" {
+  description = "Specifies whether protection against purge is enabled for this key vault. Default is true."
+  type        = bool
+  default     = true
+}
+
+variable "enabled_for_template_deployment" {
+  description = "Specifies whether Azure Resource Manager is permitted to retrieve secrets from the key vault."
+  type        = bool
+  default     = false
+}
+
+variable "key_vault_sku_name" {
+  description = "The SKU name of the Key Vault to create. Possible values are standard and premium."
+  type        = string
+  default     = "standard"
+}
+
+variable "keyvault_virtual_network_name" {
+  description = "The name of the virtual network to create the Key Vault private endpoint in."
+  type        = string
+  default     = null
+}
+
+variable "existing_keyvault_private_dns_zone" {
+  description = "The name of the existing private DNS zone to use for the Key Vault private endpoint."
+  type        = string
+  default     = null
+}
+
+variable "existing_keyvault_private_subnet_name" {
+  description = "The name of the existing private subnet to use for the Key Vault private endpoint."
+  type        = string
+  default     = null
+}

--- a/variables.resources.kubernetes.tf
+++ b/variables.resources.kubernetes.tf
@@ -547,11 +547,7 @@ variable "enable_azure_policy" {
 }
 
 
-variable "enable_key_vault_secrets_provider" {
-  description = "Addon profile to integrate Azure KeyVault with AKS"
-  type        = bool
-  default     = false
-}
+ 
 
 variable "api_server_authorized_ip_ranges" {
   description = "authorized IP ranges to communicate with K8s API"
@@ -593,12 +589,6 @@ variable "ingress_application_gateway" {
     error_message = "Application Gateway Ingress Controller requires gateway_id, subnet_cidr and subnet_id "
   }
 }
-
-
- 
-
-
-
 
 variable "key_vault_secrets_provider" {
   description = "key vault secrets provider secret rotation enabled / secret rotation interval"

--- a/variables.tf
+++ b/variables.tf
@@ -17,7 +17,7 @@ variable "environment" {
 }
 
 variable "deploy_environment" {
-  description = "Name of the workload's environnement"
+  description = "Name of the workload's environment"
   type        = string
 }
 


### PR DESCRIPTION
## Describe your changes

Added the AKS and KeyVault integration changes.

1. KeyVault Module 
2. Enabled create_aks_keyvault flag set to true in both Gov and Commercial Main.tf 
3. Added Keyvault aks access policy in modules.kubernetes.keyvault.tf 
4. Set the Keyvault access policy object_id to tf-noops-usgaz-gov-dev-aks-agentpool (AKS Cluster generated managed identity)
5. NOTE: Private Endpoint need to be added, but when we set enable_private_endpoint = true is giving errors.  Will be fixed part of the AKS private endpoint user story 
6. File variables.keyvault.tf added 2 variables existing_keyvault_private_dns_zone & existing_keyvault_private_subnet_name to enable the Private EndPoint. 

Following files modifies 

        modified:   ../scca_private_cluster_commercial/main.tf
	modified:   main.tf
	modified:   ../../modules.kubernetes.keyvault.tf
	modified:   ../../outputs.tf
	modified:   ../../resources.kubernetes.tf
	modified:   ../../variables.keyvault.tf
	modified:   ../../variables.resources.kubernetes.tf


## Issue number
#31 

#000

## Checklist before requesting a review
- [ ] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [ ] I have executed pre-commit on my machine
- [ ] I have passed pr-check on my machine

Thanks for your cooperation!

